### PR TITLE
Add comments and update code formatting in notebooks

### DIFF
--- a/exploratory_analysis/exploratory_analysis.ipynb
+++ b/exploratory_analysis/exploratory_analysis.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "dbdc6eb2",
    "metadata": {},
    "outputs": [
@@ -267,7 +267,7 @@
    ],
    "source": [
     "print(\"Dataframe Head:\")\n",
-    "display(diabetes_health_indicators_df.head())\n"
+    "display(diabetes_health_indicators_df.head())"
    ]
   },
   {

--- a/model/training.ipynb
+++ b/model/training.ipynb
@@ -14,11 +14,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ca4e36cc",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Saving data to a dataframe from a SQLite database\n",
     "conn = sqlite3.connect(\"../database/health_indicators.db\")\n",
     "diabetes_health_indicators_df = pd.read_sql(\"SELECT * FROM diabetes_health_indicators;\", conn)\n",
     "conn.close()"
@@ -258,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "51ed0571",
    "metadata": {},
    "outputs": [
@@ -420,6 +421,7 @@
    "source": [
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
+    "# Encoding categorical variables\n",
     "encoded_df = diabetes_health_indicators_df.copy()\n",
     "label_encoder = LabelEncoder()\n",
     "categorical_cols = encoded_df.select_dtypes(include=['object']).columns\n",
@@ -427,6 +429,7 @@
     "for col in categorical_cols:\n",
     "    encoded_df[col] = label_encoder.fit_transform(encoded_df[col])\n",
     "\n",
+    "# Selecting relevant columns\n",
     "encoded_df = encoded_df[[\"hba1c\", \"glucose_postprandial\", \"glucose_fasting\", \"family_history_diabetes\", \"age\", \"diagnosed_diabetes\"]]\n",
     "\n",
     "encoded_df.head(10)"
@@ -1488,7 +1491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "576c47b6",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Added explanatory comments to code cells in training.ipynb for clarity on data loading, encoding, and column selection. Removed trailing newline in display statement and reset execution counts to null in both notebooks for consistency.