### PR TITLE
Add hosted app link to README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This repository provides an end-to-end solution for predicting diabetes using he
 
 ## Usage
 
+You can access the app on this link: https://techchallenge3marcelovitti-ehahkzcbkrisneuem9zx4h.streamlit.app/ and jump directly to the step 5 if you don't want to run the code on your machine.
+
 ### 1. Create virtual environment and Install Dependencies
 
 ```sh


### PR DESCRIPTION
Added a direct link to the deployed Streamlit app in the Usage section, allowing users to access the application without running code locally.